### PR TITLE
Explicitly select python3 loader

### DIFF
--- a/folding.plugin
+++ b/folding.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=folding
 IAge=3
 Name=Simple Folding


### PR DESCRIPTION
Current gedit seems to require python3 to be explicitly defined in .plugin file. This edit works for me to use gedit-folding on current gedit.
